### PR TITLE
#5: Task 5: Discord reporting module (daily summary + review queue alerts)

### DIFF
--- a/src/utils/discord_reporter.py
+++ b/src/utils/discord_reporter.py
@@ -1,0 +1,100 @@
+import json
+import requests
+from datetime import date
+from pathlib import Path
+from src.logging import logger
+
+DISCORD_CONFIG_PATH = Path("C:/Users/juste/Documents/ElliotBrain/config/discord.json")
+DISCORD_API = "https://discord.com/api/v10"
+MAX_MSG_LEN = 1900
+
+
+def _load_config() -> dict:
+    with open(DISCORD_CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def _send(channel_id: str, text: str) -> None:
+    """Send message to Discord channel, splitting if > 1900 chars."""
+    config = _load_config()
+    token = config["bot_token"]
+    headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
+
+    chunks = []
+    while len(text) > MAX_MSG_LEN:
+        split_at = text.rfind("\n", 0, MAX_MSG_LEN)
+        if split_at == -1:
+            split_at = MAX_MSG_LEN
+        chunks.append(text[:split_at])
+        text = text[split_at:].lstrip("\n")
+    if text:
+        chunks.append(text)
+
+    for chunk in chunks:
+        try:
+            r = requests.post(
+                f"{DISCORD_API}/channels/{channel_id}/messages",
+                headers=headers,
+                json={"content": chunk},
+                timeout=10,
+            )
+            if r.status_code not in (200, 201):
+                logger.error(f"Discord send failed: {r.status_code} {r.text}")
+        except Exception as e:
+            logger.error(f"Discord send error: {e}")
+
+
+def send_daily_summary(
+    applied: list,
+    skipped: int,
+    review_count: int,
+    channel_key: str = "jobs_applied",
+) -> None:
+    config = _load_config()
+    channel_id = config["channels"][channel_key]
+    today = date.today().isoformat()
+
+    lines = [
+        f"📋 **AutoApply Daily Summary — {today}**",
+        f"Applied: {len(applied)} | Skipped: {skipped} | Needs review: {review_count}",
+    ]
+    for job in applied:
+        score = job.get("fit_score", "?")
+        lines.append(f"  • {job.get('company', '?')} — {job.get('title', '?')} — fit: {score}")
+
+    _send(channel_id, "\n".join(lines))
+
+
+def send_review_alert(job: dict) -> None:
+    config = _load_config()
+    channel_id = config["channels"]["jobs_review"]
+    score = job.get("fit_score", "?")
+    title = job.get("title", "?")
+    company = job.get("company", "?")
+    url = job.get("url", "")
+
+    msg = (
+        f"👀 **Review Required** — fit score {score}/10\n"
+        f"**{title}** at **{company}**\n"
+        f"{url}\n"
+        f"Apply? React ✅ to approve or ❌ to skip."
+    )
+    _send(channel_id, msg)
+
+
+def send_pause_alert(reason: str, daily_count: int = 0) -> None:
+    config = _load_config()
+    channel_id = config["channels"]["jobs"]
+    msg = f"🚨 **AutoApply PAUSED** — {reason}\nManual intervention required. Bot is waiting."
+    _send(channel_id, msg)
+
+
+def send_2fa_alert() -> None:
+    config = _load_config()
+    channel_id = config["channels"]["jobs"]
+    msg = (
+        "🔐 **LinkedIn 2FA Required**\n"
+        "Open LinkedIn and complete verification, then press continue.\n"
+        "Pausing for up to 5 minutes."
+    )
+    _send(channel_id, msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""
+conftest.py — shared pytest fixtures and import stubs for the test suite.
+
+Stubs src.logging before any test module imports it, so the real loguru
+setup (which reads config files) never runs during unit tests.
+"""
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Stub src.logging so discord_reporter can import `from src.logging import logger`
+# without triggering the real loguru initialisation that reads config files.
+_logging_stub = types.ModuleType("src.logging")
+_logging_stub.logger = MagicMock()
+sys.modules.setdefault("src.logging", _logging_stub)

--- a/tests/test_task5_discord_reporter.py
+++ b/tests/test_task5_discord_reporter.py
@@ -1,0 +1,177 @@
+"""
+TDD tests for Task 5: discord_reporter.py
+Tests are written BEFORE implementation (TDD protocol).
+All tests mock requests.post and _load_config to avoid real network/disk calls.
+
+conftest.py stubs src.logging before this module loads.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+import src.utils.discord_reporter as reporter
+
+FAKE_CONFIG = {
+    "bot_token": "fake-token-abc123",
+    "channels": {
+        "jobs_applied": "1111111111111111111",
+        "jobs_review":  "2222222222222222222",
+        "jobs":         "3333333333333333333",
+    },
+}
+
+
+class TestSendDailySummary(unittest.TestCase):
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_send_daily_summary_posts_to_jobs_applied_channel(self, mock_post, _cfg):
+        """Must POST to the jobs_applied channel ID."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        reporter.send_daily_summary(applied=[], skipped=0, review_count=0)
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0]
+        self.assertIn("1111111111111111111", url)
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_send_daily_summary_formats_applied_list(self, mock_post, _cfg):
+        """Message must include company, title, fit_score, and counts."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        jobs = [{"company": "Acme", "title": "Engineer", "fit_score": 8}]
+        reporter.send_daily_summary(applied=jobs, skipped=2, review_count=1)
+        content = mock_post.call_args[1]["json"]["content"]
+        self.assertIn("Acme", content)
+        self.assertIn("Engineer", content)
+        self.assertIn("8", content)
+        self.assertIn("Applied: 1", content)
+        self.assertIn("Skipped: 2", content)
+        self.assertIn("Needs review: 1", content)
+
+
+class TestSendReviewAlert(unittest.TestCase):
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_send_review_alert_posts_to_jobs_review_channel(self, mock_post, _cfg):
+        """Must POST to the jobs_review channel ID."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        reporter.send_review_alert({"title": "Dev", "company": "Corp", "fit_score": 6, "url": "http://x.com"})
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0]
+        self.assertIn("2222222222222222222", url)
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_send_review_alert_formats_job_details(self, mock_post, _cfg):
+        """Message must include title, company, fit_score, and url."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        job = {"title": "Staff Eng", "company": "TechCo", "fit_score": 7, "url": "https://jobs.example.com/42"}
+        reporter.send_review_alert(job)
+        content = mock_post.call_args[1]["json"]["content"]
+        self.assertIn("Staff Eng", content)
+        self.assertIn("TechCo", content)
+        self.assertIn("7", content)
+        self.assertIn("https://jobs.example.com/42", content)
+
+
+class TestSendPauseAlert(unittest.TestCase):
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_send_pause_alert_posts_to_jobs_channel(self, mock_post, _cfg):
+        """Must POST to the generic jobs channel."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        reporter.send_pause_alert("rate limit hit")
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0]
+        self.assertIn("3333333333333333333", url)
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_send_pause_alert_includes_reason(self, mock_post, _cfg):
+        """Message must contain the reason string."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        reporter.send_pause_alert("captcha detected")
+        content = mock_post.call_args[1]["json"]["content"]
+        self.assertIn("captcha detected", content)
+
+
+class TestSend2faAlert(unittest.TestCase):
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_send_2fa_alert_posts_to_jobs_channel(self, mock_post, _cfg):
+        """2FA alert must POST to the generic jobs channel."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        reporter.send_2fa_alert()
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0]
+        self.assertIn("3333333333333333333", url)
+
+
+class TestChunking(unittest.TestCase):
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_long_message_is_chunked(self, mock_post, _cfg):
+        """A message longer than 1900 chars must result in multiple POST calls."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        # 25 lines * 101 chars each = 2525 chars total
+        long_text = "\n".join(["x" * 100] * 25)
+        reporter._send("3333333333333333333", long_text)
+        self.assertGreater(mock_post.call_count, 1)
+        for c in mock_post.call_args_list:
+            chunk_content = c[1]["json"]["content"]
+            self.assertLessEqual(len(chunk_content), 1900)
+
+
+class TestApiFailureHandling(unittest.TestCase):
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_discord_api_failure_does_not_raise(self, mock_post, _cfg):
+        """A non-200 response must log an error but NOT raise an exception."""
+        mock_post.return_value = MagicMock(status_code=500, text="Internal Server Error")
+        try:
+            reporter._send("3333333333333333333", "test message")
+        except Exception as e:
+            self.fail(f"_send raised an exception on API failure: {e}")
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post", side_effect=ConnectionError("network down"))
+    def test_discord_network_error_does_not_raise(self, mock_post, _cfg):
+        """A network exception must be caught and logged, not propagated."""
+        try:
+            reporter._send("3333333333333333333", "test message")
+        except Exception as e:
+            self.fail(f"_send raised an exception on network error: {e}")
+
+
+class TestLoadConfig(unittest.TestCase):
+
+    def test_load_config_reads_discord_json(self):
+        """_load_config must return a dict with bot_token and channels keys."""
+        result = reporter._load_config()
+        self.assertIn("bot_token", result)
+        self.assertIn("channels", result)
+        self.assertIsInstance(result["channels"], dict)
+
+
+class TestChunkingNoNewline(unittest.TestCase):
+
+    @patch("src.utils.discord_reporter._load_config", return_value=FAKE_CONFIG)
+    @patch("src.utils.discord_reporter.requests.post")
+    def test_long_message_no_newline_splits_at_max_len(self, mock_post, _cfg):
+        """A message with no newlines longer than 1900 chars must still be split."""
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        # Single block of 2500 chars, no newlines — forces the split_at == -1 branch
+        long_text = "y" * 2500
+        reporter._send("3333333333333333333", long_text)
+        self.assertGreater(mock_post.call_count, 1)
+        for c in mock_post.call_args_list:
+            chunk_content = c[1]["json"]["content"]
+            self.assertLessEqual(len(chunk_content), 1900)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #5

## Changes
- Added `jobs_applied` and `jobs_review` channel keys to `discord.json` (both map to existing `jobs` channel until dedicated channels are created)
- Built `src/utils/discord_reporter.py` with `send_daily_summary`, `send_review_alert`, `send_pause_alert`, and `send_2fa_alert` functions
- Message chunking logic splits messages >1900 chars on newline boundaries, falling back to hard split when no newline exists
- All Discord API failures and network errors are caught and logged — never propagated
- Added `tests/conftest.py` to stub `src.logging` cleanly across the test suite
- Added `tests/test_task5_discord_reporter.py` with 12 tests covering all public functions and edge cases

## Tests
- Tests added: 12
- Coverage on modified files: 100%
- Overall coverage delta: +100% on discord_reporter.py

## TDD confirmation
- [x] Tests written before implementation
- [x] All tests pass
- [x] Coverage >=90% on modified files