### PR TITLE
[WIP] #15: Phase 1 — Harden job_queue.py for morning brief integration

### DIFF
--- a/tests/test_indeed_handler.py
+++ b/tests/test_indeed_handler.py
@@ -1,0 +1,223 @@
+"""
+tests/test_indeed_handler.py
+
+Failing tests for Issue #13: Phase 1 — Indeed Easy Apply handler.
+Tests are written BEFORE implementation (TDD).
+"""
+import sys
+import types
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub src.logging before any module under test is imported
+# ---------------------------------------------------------------------------
+if "src.logging" not in sys.modules:
+    _logging_stub = types.ModuleType("src.logging")
+    _logging_stub.logger = MagicMock()
+    sys.modules["src.logging"] = _logging_stub
+
+# Stub src.utils.discord_reporter so we can assert on send_pause_alert calls
+_discord_stub = types.ModuleType("src.utils.discord_reporter")
+_discord_stub.send_pause_alert = MagicMock()
+sys.modules["src.utils.discord_reporter"] = _discord_stub
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_handler(answer_bank=None):
+    """Return an IndeedApplyHandler with mocked driver and llm_manager."""
+    from src.ai_hawk.indeed_handler import IndeedApplyHandler
+
+    driver = MagicMock()
+    llm_manager = MagicMock()
+    return IndeedApplyHandler(
+        driver=driver,
+        llm_manager=llm_manager,
+        answer_bank=answer_bank or {},
+    )
+
+
+def _job(salary_max=None, title="Software Engineer", company="Acme", url="https://indeed.com/job/1"):
+    """Return a minimal job dict."""
+    return {"title": title, "company": company, "url": url, "salary_max": salary_max}
+
+
+# ---------------------------------------------------------------------------
+# Import test
+# ---------------------------------------------------------------------------
+
+class TestImport:
+    def test_indeed_handler_is_importable(self):
+        """IndeedApplyHandler must be importable from src.ai_hawk.indeed_handler."""
+        from src.ai_hawk.indeed_handler import IndeedApplyHandler  # noqa: F401
+        assert IndeedApplyHandler is not None
+
+    def test_indeed_handler_exported_from_package(self):
+        """IndeedApplyHandler must be accessible via src.ai_hawk."""
+        import src.ai_hawk as pkg
+        assert hasattr(pkg, "IndeedApplyHandler"), (
+            "IndeedApplyHandler not exported from src/ai_hawk/__init__.py"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _should_skip tests
+# ---------------------------------------------------------------------------
+
+class TestShouldSkip:
+    def test_skip_when_salary_max_below_100k(self):
+        """_should_skip returns True when salary_max < 100000."""
+        handler = _make_handler()
+        job = _job(salary_max=80000)
+        assert handler._should_skip(job) is True
+
+    def test_skip_when_salary_max_exactly_99999(self):
+        """_should_skip returns True for salary_max = 99999."""
+        handler = _make_handler()
+        assert handler._should_skip(_job(salary_max=99999)) is True
+
+    def test_no_skip_when_salary_max_is_150k(self):
+        """_should_skip returns False for a normal $150k job."""
+        handler = _make_handler()
+        job = _job(salary_max=150000)
+        assert handler._should_skip(job) is False
+
+    def test_no_skip_when_salary_max_is_none(self):
+        """_should_skip returns False when salary_max is not listed."""
+        handler = _make_handler()
+        job = _job(salary_max=None)
+        assert handler._should_skip(job) is False
+
+    def test_no_skip_when_salary_max_exactly_100k(self):
+        """_should_skip returns False when salary_max == 100000 (boundary)."""
+        handler = _make_handler()
+        assert handler._should_skip(_job(salary_max=100000)) is False
+
+
+# ---------------------------------------------------------------------------
+# Daily cap tests
+# ---------------------------------------------------------------------------
+
+class TestDailyCap:
+    def test_apply_raises_after_30_calls(self):
+        """apply raises RuntimeError (or similar) after 30 successful applications."""
+        handler = _make_handler()
+
+        # Force _should_skip to always return False and _do_apply to succeed
+        handler._should_skip = MagicMock(return_value=False)
+        handler._do_apply = MagicMock(return_value=True)
+
+        job = _job()
+        # First 30 calls should succeed
+        for _ in range(30):
+            handler.apply(job)
+
+        # 31st call must raise or send alert and stop
+        with pytest.raises(Exception):
+            handler.apply(job)
+
+    def test_daily_cap_triggers_discord_alert(self):
+        """Discord pause alert fires when daily cap is reached."""
+        from src.utils.discord_reporter import send_pause_alert
+
+        send_pause_alert.reset_mock()
+
+        handler = _make_handler()
+        handler._should_skip = MagicMock(return_value=False)
+        handler._do_apply = MagicMock(return_value=True)
+
+        job = _job()
+        for _ in range(30):
+            handler.apply(job)
+
+        try:
+            handler.apply(job)
+        except Exception:
+            pass
+
+        send_pause_alert.assert_called()
+        # The call reason must mention cap
+        call_reason = send_pause_alert.call_args[0][0] if send_pause_alert.call_args[0] else \
+            send_pause_alert.call_args[1].get("reason", "")
+        assert "cap" in call_reason.lower() or "daily" in call_reason.lower()
+
+    def test_applications_today_counter_increments(self):
+        """applications_today counter increments on each successful apply."""
+        handler = _make_handler()
+        handler._should_skip = MagicMock(return_value=False)
+        handler._do_apply = MagicMock(return_value=True)
+
+        job = _job()
+        handler.apply(job)
+        handler.apply(job)
+        assert handler.applications_today == 2
+
+
+# ---------------------------------------------------------------------------
+# _fill_form_field tests
+# ---------------------------------------------------------------------------
+
+class TestFillFormField:
+    def test_answer_bank_used_before_llm(self):
+        """_fill_form_field checks answer_bank before calling llm_manager.invoke."""
+        answer_bank = {"years of experience": "5"}
+        handler = _make_handler(answer_bank=answer_bank)
+
+        field_element = MagicMock()
+        handler._fill_form_field(field_element, "Years of Experience")
+
+        # LLM must NOT have been called
+        handler.llm_manager.invoke.assert_not_called()
+
+    def test_llm_called_when_answer_not_in_bank(self):
+        """_fill_form_field calls llm_manager.invoke when question not in answer_bank."""
+        handler = _make_handler(answer_bank={})
+        handler.llm_manager.invoke.return_value = MagicMock(content="3 years")
+
+        field_element = MagicMock()
+        handler._fill_form_field(field_element, "What is your notice period?")
+
+        handler.llm_manager.invoke.assert_called_once()
+
+    def test_answer_bank_lookup_is_case_insensitive(self):
+        """answer_bank lookup normalises key case."""
+        answer_bank = {"Years Of Experience": "7"}
+        handler = _make_handler(answer_bank=answer_bank)
+
+        field_element = MagicMock()
+        handler._fill_form_field(field_element, "years of experience")
+        handler.llm_manager.invoke.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Consecutive failures / Discord alert
+# ---------------------------------------------------------------------------
+
+class TestConsecutiveFailures:
+    def test_discord_alert_after_3_consecutive_failures(self):
+        """After 3 consecutive failures, send_pause_alert is called and an exception raised."""
+        from src.utils.discord_reporter import send_pause_alert
+
+        send_pause_alert.reset_mock()
+
+        handler = _make_handler()
+        handler._should_skip = MagicMock(return_value=False)
+        handler._do_apply = MagicMock(side_effect=Exception("apply failed"))
+
+        job = _job()
+        with pytest.raises(Exception):
+            for _ in range(4):
+                try:
+                    handler.apply(job)
+                except Exception as exc:
+                    # Re-raise only when it's the escalation raise (after 3 failures)
+                    if "consecutive" in str(exc).lower() or "pause" in str(exc).lower():
+                        raise
+                    # Regular failure — keep counting
+                    continue
+
+        send_pause_alert.assert_called()

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -1,0 +1,240 @@
+"""
+tests/test_job_queue.py
+
+TDD tests for job_queue.py — Issue #15
+Validates the get_queue() public API against the morning brief integration spec.
+
+Spec requirements:
+- Returns [] when queue.json does not exist
+- Filters out jobs with fit_score < 7.5
+- Deduplicates against job_history by company+title
+- Returns valid jobs with all required fields present
+- Handles malformed entries gracefully (missing keys = skip, not crash)
+"""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+import sys
+sys.path.insert(0, str(Path("D:/Repos/Jobs_Applier_AI_Agent_AIHawk")))
+
+from src.utils.job_queue import get_queue, FIT_SCORE_THRESHOLD
+
+REQUIRED_FIELDS = {"title", "company", "url", "board", "fit_score", "resume_pdf", "date"}
+
+VALID_JOB = {
+    "title": "Senior Engineer",
+    "company": "Acme Corp",
+    "url": "https://linkedin.com/jobs/1",
+    "board": "linkedin",
+    "fit_score": 8.5,
+    "salary_range": "$120k-$150k",
+    "resume_pdf": "/path/to/resume.pdf",
+    "cover_letter": "/path/to/cover.pdf",
+    "date": "2026-03-11",
+}
+
+BORDERLINE_JOB = {
+    "title": "Mid Engineer",
+    "company": "Beta Inc",
+    "url": "https://indeed.com/jobs/2",
+    "board": "indeed",
+    "fit_score": 7.5,
+    "resume_pdf": "/path/to/resume.pdf",
+    "date": "2026-03-11",
+}
+
+LOW_SCORE_JOB = {
+    "title": "Junior Engineer",
+    "company": "Gamma LLC",
+    "url": "https://ziprecruiter.com/jobs/3",
+    "board": "ziprecruiter",
+    "fit_score": 6.0,
+    "resume_pdf": "/path/to/resume.pdf",
+    "date": "2026-03-11",
+}
+
+HISTORY_WITH_ACME = (
+    "| Date | Company | Title | Status | Job ID |\n"
+    "| --- | --- | --- | --- | --- |\n"
+    "| 2026-03-01 | Acme Corp | Senior Engineer | Applied | li_001 |\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Returns [] when queue.json does not exist
+# ---------------------------------------------------------------------------
+
+def test_get_queue_returns_empty_when_file_missing(tmp_path):
+    result = get_queue(
+        queue_path=tmp_path / "nonexistent.json",
+        history_path=tmp_path / "nonexistent.md",
+    )
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Filters out jobs with fit_score < 7.5 (exact boundary)
+# ---------------------------------------------------------------------------
+
+def test_get_queue_filters_low_fit_score(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([LOW_SCORE_JOB]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_includes_job_at_exact_threshold(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([BORDERLINE_JOB]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert len(result) == 1
+    assert result[0]["company"] == "Beta Inc"
+
+
+def test_get_queue_includes_job_above_threshold(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([VALID_JOB]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert len(result) == 1
+    assert result[0]["company"] == "Acme Corp"
+
+
+# ---------------------------------------------------------------------------
+# 3. Deduplicates against job_history by company+title
+# ---------------------------------------------------------------------------
+
+def test_get_queue_deduplicates_by_company_and_title(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([VALID_JOB]))
+    h = tmp_path / "job_history.md"
+    h.write_text(HISTORY_WITH_ACME)
+    result = get_queue(queue_path=q, history_path=h)
+    assert result == []
+
+
+def test_get_queue_dedup_different_company_passes(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([BORDERLINE_JOB]))
+    h = tmp_path / "job_history.md"
+    h.write_text(HISTORY_WITH_ACME)
+    result = get_queue(queue_path=q, history_path=h)
+    assert len(result) == 1
+
+
+def test_get_queue_dedup_same_company_different_title_passes(tmp_path):
+    q = tmp_path / "queue.json"
+    different_title_job = {**VALID_JOB, "title": "Staff Engineer"}
+    q.write_text(json.dumps([different_title_job]))
+    h = tmp_path / "job_history.md"
+    h.write_text(HISTORY_WITH_ACME)
+    result = get_queue(queue_path=q, history_path=h)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Returns valid jobs with all required fields
+# ---------------------------------------------------------------------------
+
+def test_get_queue_returned_jobs_have_required_fields(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([VALID_JOB]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert len(result) == 1
+    for field in REQUIRED_FIELDS:
+        assert field in result[0], f"Missing required field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# 5. Handles malformed entries gracefully (missing keys = skip, not crash)
+# ---------------------------------------------------------------------------
+
+def test_get_queue_skips_entry_missing_title(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "title"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_skips_entry_missing_company(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "company"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_skips_entry_missing_url(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "url"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_skips_entry_missing_fit_score(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "fit_score"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_skips_entry_missing_resume_pdf(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "resume_pdf"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_skips_entry_missing_date(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "date"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_skips_entry_missing_board(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "board"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_skips_malformed_but_returns_valid_sibling(tmp_path):
+    bad = {k: v for k, v in VALID_JOB.items() if k != "title"}
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([bad, BORDERLINE_JOB]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert len(result) == 1
+    assert result[0]["company"] == "Beta Inc"
+
+
+def test_get_queue_handles_empty_list(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_handles_invalid_json(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text("not valid json {{{")
+    result = get_queue(queue_path=q, history_path=tmp_path / "history.md")
+    assert result == []
+
+
+def test_get_queue_handles_missing_history_file(tmp_path):
+    q = tmp_path / "queue.json"
+    q.write_text(json.dumps([VALID_JOB]))
+    result = get_queue(queue_path=q, history_path=tmp_path / "nonexistent.md")
+    assert len(result) == 1
+
+
+def test_get_queue_fit_score_threshold_constant():
+    assert FIT_SCORE_THRESHOLD == 7.5

--- a/tests/test_main_wiring.py
+++ b/tests/test_main_wiring.py
@@ -1,0 +1,174 @@
+"""
+test_main_wiring.py — TDD tests for Issue #12.
+
+Verifies:
+  1. AIHawkBotFacade can be imported from src.ai_hawk.bot_facade
+  2. AIHawkJobManager can be imported from src.ai_hawk (via __init__.py)
+  3. The CLI has a 'run' command registered on the cli group in main.py
+"""
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — stub heavy optional deps so import tests stay unit-level
+# ---------------------------------------------------------------------------
+
+def _stub_module(name: str) -> types.ModuleType:
+    """Register a lightweight MagicMock module in sys.modules."""
+    mod = types.ModuleType(name)
+    sys.modules.setdefault(name, mod)
+    return mod
+
+
+def _ensure_selenium_stubs() -> None:
+    """Stub selenium and webdriver_manager so imports don't need the real wheels."""
+    for name in [
+        "selenium",
+        "selenium.webdriver",
+        "selenium.webdriver.common",
+        "selenium.webdriver.common.by",
+        "selenium.webdriver.support",
+        "selenium.webdriver.support.expected_conditions",
+        "selenium.webdriver.support.ui",
+        "selenium.common",
+        "selenium.common.exceptions",
+        "selenium.webdriver.chrome",
+        "selenium.webdriver.chrome.service",
+        "webdriver_manager",
+        "webdriver_manager.chrome",
+        "inquirer",
+    ]:
+        _stub_module(name)
+
+    # Give By.CLASS_NAME etc. real-ish attributes
+    by_mod = sys.modules["selenium.webdriver.common.by"]
+    by_class = type("By", (), {"CLASS_NAME": "class_name", "XPATH": "xpath"})
+    by_mod.By = by_class
+
+    # WebDriverWait / EC stubs
+    wdw_mod = sys.modules["selenium.webdriver.support.ui"]
+    wdw_mod.WebDriverWait = MagicMock()
+    ec_mod = sys.modules["selenium.webdriver.support.expected_conditions"]
+    ec_mod.presence_of_element_located = MagicMock()
+
+    exc_mod = sys.modules["selenium.common.exceptions"]
+    exc_mod.NoSuchElementException = Exception
+    exc_mod.TimeoutException = Exception
+    exc_mod.WebDriverException = Exception
+
+    svc_mod = sys.modules["selenium.webdriver.chrome.service"]
+    svc_mod.Service = MagicMock()
+
+    cdm_mod = sys.modules["webdriver_manager.chrome"]
+    cdm_mod.ChromeDriverManager = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: AIHawkBotFacade importable from src.ai_hawk.bot_facade
+# ---------------------------------------------------------------------------
+
+class TestBotFacadeImport:
+    """AIHawkBotFacade must be importable from src.ai_hawk.bot_facade."""
+
+    def test_aihawk_bot_facade_importable(self):
+        """Importing AIHawkBotFacade should not raise."""
+        _ensure_selenium_stubs()
+        # Stub discord_reporter dependency
+        _stub_module("src.utils.discord_reporter").send_pause_alert = MagicMock()
+        _stub_module("src.utils.linkedin_auth").ensure_logged_in = MagicMock()
+
+        from src.ai_hawk.bot_facade import AIHawkBotFacade  # noqa: F401
+        assert AIHawkBotFacade is not None
+
+    def test_aihawk_bot_facade_is_a_class(self):
+        """AIHawkBotFacade must be a class (not a function or module)."""
+        _ensure_selenium_stubs()
+        from src.ai_hawk.bot_facade import AIHawkBotFacade
+        assert isinstance(AIHawkBotFacade, type)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: AIHawkJobManager importable from src.ai_hawk
+# ---------------------------------------------------------------------------
+
+class TestAIHawkInitExports:
+    """src.ai_hawk.__init__ must export AIHawkBotFacade and AIHawkJobManager."""
+
+    def test_ai_hawk_init_exports_aihawk_bot_facade(self):
+        """from src.ai_hawk import AIHawkBotFacade must succeed."""
+        _ensure_selenium_stubs()
+        _stub_module("src.utils.discord_reporter").send_pause_alert = MagicMock()
+        _stub_module("src.utils.linkedin_auth").ensure_logged_in = MagicMock()
+
+        import src.ai_hawk as ai_hawk_pkg
+        importlib.reload(ai_hawk_pkg)
+        assert hasattr(ai_hawk_pkg, "AIHawkBotFacade"), (
+            "src.ai_hawk.__init__ must export AIHawkBotFacade"
+        )
+
+    def test_ai_hawk_init_exports_aihawk_job_manager(self):
+        """from src.ai_hawk import AIHawkJobManager must succeed."""
+        _ensure_selenium_stubs()
+
+        import src.ai_hawk as ai_hawk_pkg
+        importlib.reload(ai_hawk_pkg)
+        assert hasattr(ai_hawk_pkg, "AIHawkJobManager"), (
+            "src.ai_hawk.__init__ must export AIHawkJobManager"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: main.py CLI group has a 'run' command
+# ---------------------------------------------------------------------------
+
+class TestMainCliRunCommand:
+    """The Click cli group in main.py must register a 'run' command."""
+
+    def _load_cli(self):
+        """Import main module (fresh) and return the cli Click group."""
+        _ensure_selenium_stubs()
+
+        # Stub heavy main.py imports
+        _stub_module("src.utils.discord_reporter").send_pause_alert = MagicMock()
+        _stub_module("src.utils.linkedin_auth").ensure_logged_in = MagicMock()
+
+        for name in [
+            "src.libs.resume_and_cover_builder",
+            "src.resume_schemas.job_application_profile",
+            "src.resume_schemas.resume",
+            "src.utils.chrome_utils",
+            "src.utils.constants",
+        ]:
+            mod = _stub_module(name)
+            # Provide attribute names consumed by main.py
+            mod.ResumeFacade = MagicMock()
+            mod.ResumeGenerator = MagicMock()
+            mod.StyleManager = MagicMock()
+            mod.JobApplicationProfile = MagicMock()
+            mod.Resume = MagicMock()
+            mod.init_browser = MagicMock()
+            mod.PLAIN_TEXT_RESUME_YAML = "plain_text_resume.yaml"
+            mod.SECRETS_YAML = "secrets.yaml"
+            mod.WORK_PREFERENCES_YAML = "work_preferences.yaml"
+
+        # Force reimport of main
+        sys.modules.pop("main", None)
+        import main as main_mod
+        return main_mod
+
+    def test_cli_group_exists(self):
+        """main module must expose a 'cli' Click group."""
+        main_mod = self._load_cli()
+        assert hasattr(main_mod, "cli"), "main.py must define a Click 'cli' group"
+
+    def test_cli_has_run_command(self):
+        """The 'cli' group must have a registered 'run' command."""
+        main_mod = self._load_cli()
+        assert "run" in main_mod.cli.commands, (
+            "cli group must register a 'run' command via @cli.command()"
+        )

--- a/tests/test_ziprecruiter_handler.py
+++ b/tests/test_ziprecruiter_handler.py
@@ -1,0 +1,309 @@
+"""
+tests/test_ziprecruiter_handler.py
+
+Failing tests for ZipRecruiterApplyHandler (Issue #14).
+Written BEFORE implementation — all tests must FAIL on first run.
+"""
+import sys
+import types
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stubs — must be registered before the module under test is imported
+# ---------------------------------------------------------------------------
+
+# src.logging stub (conftest may already register this, but we ensure it here)
+if "src.logging" not in sys.modules:
+    _logging_stub = types.ModuleType("src.logging")
+    _logging_stub.logger = MagicMock()
+    sys.modules["src.logging"] = _logging_stub
+
+# selenium stubs
+for _mod in [
+    "selenium",
+    "selenium.webdriver",
+    "selenium.webdriver.common",
+    "selenium.webdriver.common.by",
+    "selenium.webdriver.support",
+    "selenium.webdriver.support.ui",
+    "selenium.webdriver.support.expected_conditions",
+    "selenium.common",
+    "selenium.common.exceptions",
+]:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+# Populate the specific attributes tests and implementation need
+_by = sys.modules["selenium.webdriver.common.by"]
+_by.By = MagicMock()
+
+_ec = sys.modules["selenium.webdriver.support.expected_conditions"]
+_ec.element_to_be_clickable = MagicMock()
+_ec.presence_of_element_located = MagicMock()
+
+_ui = sys.modules["selenium.webdriver.support.ui"]
+_ui.WebDriverWait = MagicMock()
+_ui.Select = MagicMock()
+
+_exc = sys.modules["selenium.common.exceptions"]
+_exc.NoSuchElementException = type("NoSuchElementException", (Exception,), {})
+_exc.TimeoutException = type("TimeoutException", (Exception,), {})
+_exc.ElementNotInteractableException = type("ElementNotInteractableException", (Exception,), {})
+
+# discord_reporter stub
+if "src.utils.discord_reporter" not in sys.modules:
+    _dr = types.ModuleType("src.utils.discord_reporter")
+    _dr.send_pause_alert = MagicMock()
+    sys.modules["src.utils"] = types.ModuleType("src.utils")
+    sys.modules["src.utils.discord_reporter"] = _dr
+
+# ---------------------------------------------------------------------------
+# Import the module under test (will FAIL until implementation exists)
+# ---------------------------------------------------------------------------
+
+from src.ai_hawk.ziprecruiter_handler import ZipRecruiterApplyHandler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mock_driver():
+    return MagicMock()
+
+
+@pytest.fixture()
+def mock_llm():
+    llm = MagicMock()
+    llm.invoke.return_value = MagicMock(content="LLM answer")
+    return llm
+
+
+@pytest.fixture()
+def answer_bank():
+    return {"years of experience": "5", "preferred salary": "150000"}
+
+
+@pytest.fixture()
+def handler(mock_driver, mock_llm, answer_bank):
+    return ZipRecruiterApplyHandler(
+        driver=mock_driver,
+        llm_manager=mock_llm,
+        answer_bank=answer_bank,
+    )
+
+
+@pytest.fixture()
+def normal_job():
+    return {
+        "role": "Software Engineer",
+        "company": "Acme Corp",
+        "url": "https://www.ziprecruiter.com/jobs/acme-12345",
+        "salary_max": 150000,
+    }
+
+
+@pytest.fixture()
+def low_salary_job():
+    return {
+        "role": "Junior Dev",
+        "company": "Cheapo Inc",
+        "url": "https://www.ziprecruiter.com/jobs/cheapo-99999",
+        "salary_max": 80000,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Import / instantiation
+# ---------------------------------------------------------------------------
+
+class TestImportAndInit:
+    def test_importable(self):
+        """ZipRecruiterApplyHandler must be importable from src.ai_hawk.ziprecruiter_handler."""
+        assert ZipRecruiterApplyHandler is not None
+
+    def test_initial_state(self, handler):
+        """Handler initialises with zero applications and DAILY_CAP=50."""
+        assert handler.applications_today == 0
+        assert handler.DAILY_CAP == 50
+        assert handler.consecutive_failures == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. _is_one_click
+# ---------------------------------------------------------------------------
+
+class TestIsOneClick:
+    def test_returns_true_when_button_present(self, handler, mock_driver):
+        """_is_one_click returns True when a '1-Click Apply' element is in the DOM."""
+        btn = MagicMock()
+        btn.get_attribute.return_value = "1-Click Apply"
+        mock_driver.find_elements.return_value = [btn]
+        assert handler._is_one_click() is True
+
+    def test_returns_false_when_no_button(self, handler, mock_driver):
+        """_is_one_click returns False when no '1-Click Apply' element exists."""
+        mock_driver.find_elements.return_value = []
+        assert handler._is_one_click() is False
+
+    def test_returns_false_when_aria_label_differs(self, handler, mock_driver):
+        """_is_one_click returns False when the button has a different aria-label."""
+        btn = MagicMock()
+        btn.get_attribute.return_value = "Easy Apply"
+        mock_driver.find_elements.return_value = [btn]
+        assert handler._is_one_click() is False
+
+
+# ---------------------------------------------------------------------------
+# 3. _should_skip
+# ---------------------------------------------------------------------------
+
+class TestShouldSkip:
+    def test_skips_when_salary_max_below_100k(self, handler, low_salary_job):
+        """_should_skip returns True when listed salary max < $100,000."""
+        assert handler._should_skip(low_salary_job) is True
+
+    def test_does_not_skip_normal_job(self, handler, normal_job):
+        """_should_skip returns False for a job with acceptable salary."""
+        assert handler._should_skip(normal_job) is False
+
+    def test_does_not_skip_when_no_salary_key(self, handler):
+        """_should_skip returns False when salary_max is absent from the job dict."""
+        job = {"role": "Dev", "company": "Foo", "url": "https://ziprecruiter.com/j/1"}
+        assert handler._should_skip(job) is False
+
+    def test_does_not_skip_at_exactly_100k(self, handler):
+        """_should_skip returns False when salary_max == 100000 (boundary)."""
+        job = {
+            "role": "Dev",
+            "company": "Foo",
+            "url": "https://ziprecruiter.com/j/2",
+            "salary_max": 100000,
+        }
+        assert handler._should_skip(job) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Daily cap enforcement in apply()
+# ---------------------------------------------------------------------------
+
+class TestDailyCap:
+    def test_raises_after_50_applications(self, handler, normal_job):
+        """apply() raises RuntimeError (or similar) after DAILY_CAP submissions."""
+        handler.applications_today = 50
+
+        with patch(
+            "src.utils.discord_reporter.send_pause_alert"
+        ) as mock_alert, patch(
+            "src.ai_hawk.ziprecruiter_handler.send_pause_alert"
+        ) as mock_alert2:
+            with pytest.raises(Exception):
+                handler.apply(normal_job)
+
+    def test_sends_discord_alert_at_cap(self, handler, normal_job):
+        """apply() calls send_pause_alert when the daily cap is hit."""
+        handler.applications_today = 50
+
+        with patch(
+            "src.ai_hawk.ziprecruiter_handler.send_pause_alert"
+        ) as mock_alert:
+            with pytest.raises(Exception):
+                handler.apply(normal_job)
+            mock_alert.assert_called_once()
+
+    def test_increments_counter_on_success(self, handler, mock_driver, normal_job):
+        """apply() increments applications_today on a successful one-click apply."""
+        # Simulate one-click path: button found, click succeeds, modal confirmed
+        btn = MagicMock()
+        btn.get_attribute.return_value = "1-Click Apply"
+        mock_driver.find_elements.return_value = [btn]
+        mock_driver.find_element.return_value = MagicMock()
+        mock_driver.page_source = "<html>success</html>"
+
+        with patch("time.sleep"):
+            result = handler.apply(normal_job)
+
+        assert handler.applications_today == 1
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# 5. _fill_form_field — answer_bank lookup before LLM
+# ---------------------------------------------------------------------------
+
+class TestFillFormField:
+    def test_uses_answer_bank_before_llm(self, handler, mock_llm):
+        """_fill_form_field uses answer_bank hit and does NOT call LLM."""
+        field = MagicMock()
+        field.get_attribute.return_value = "text"
+
+        handler._fill_form_field(field, "years of experience")
+
+        mock_llm.invoke.assert_not_called()
+        field.clear.assert_called_once()
+        field.send_keys.assert_called_once_with("5")
+
+    def test_falls_back_to_llm_when_not_in_answer_bank(self, handler, mock_llm):
+        """_fill_form_field calls LLM when question is not in answer_bank."""
+        field = MagicMock()
+        field.get_attribute.return_value = "text"
+
+        handler._fill_form_field(field, "what is your greatest weakness?")
+
+        mock_llm.invoke.assert_called_once()
+        field.send_keys.assert_called()
+
+    def test_answer_bank_lookup_is_case_insensitive(self, handler, mock_llm):
+        """_fill_form_field matches answer_bank keys case-insensitively."""
+        field = MagicMock()
+        field.get_attribute.return_value = "text"
+
+        handler._fill_form_field(field, "Years Of Experience")
+
+        mock_llm.invoke.assert_not_called()
+        field.send_keys.assert_called_once_with("5")
+
+
+# ---------------------------------------------------------------------------
+# 6. Three consecutive failures trigger Discord alert + raise
+# ---------------------------------------------------------------------------
+
+class TestConsecutiveFailures:
+    def test_three_failures_trigger_alert_and_raise(self, handler, mock_driver, normal_job):
+        """After 3 consecutive failures apply() sends Discord alert and raises."""
+        # Make _is_one_click return False and multi-step form fail
+        mock_driver.find_elements.return_value = []
+        mock_driver.find_element.side_effect = Exception("element not found")
+
+        with patch("src.ai_hawk.ziprecruiter_handler.send_pause_alert") as mock_alert:
+            for _ in range(2):
+                try:
+                    handler.apply(normal_job)
+                except Exception:
+                    pass
+
+            with pytest.raises(Exception):
+                handler.apply(normal_job)
+
+            mock_alert.assert_called()
+            alert_call_args = mock_alert.call_args[0][0] if mock_alert.call_args else ""
+            assert "consecutive" in alert_call_args.lower() or mock_alert.called
+
+
+# ---------------------------------------------------------------------------
+# 7. CAPTCHA detection
+# ---------------------------------------------------------------------------
+
+class TestCaptchaDetection:
+    def test_captcha_in_page_source_triggers_alert(self, handler, mock_driver, normal_job):
+        """apply() detects 'captcha' in page_source and calls send_pause_alert."""
+        mock_driver.page_source = "<html>please solve the captcha challenge</html>"
+        mock_driver.find_elements.return_value = []
+
+        with patch("src.ai_hawk.ziprecruiter_handler.send_pause_alert") as mock_alert:
+            with pytest.raises(Exception):
+                handler.apply(normal_job)
+            mock_alert.assert_called()


### PR DESCRIPTION
Closes #15

## Changes
- Add `get_queue()` public API function with schema validation, fit_score filtering (>= 7.5), and company+title dedup against job_history.md
- Add `FIT_SCORE_THRESHOLD = 7.5` constant to match morning brief spec
- Add `validate_job_entry()` helper — skips malformed entries, never crashes
- Add `load_history_pairs()` helper to parse company+title pairs from job_history.md
- Add comprehensive test suite at `tests/test_job_queue.py` (18 tests)

## Tests
- Tests added: 18
- Coverage on modified files: pending
- Overall coverage delta: pending

## TDD confirmation
- [ ] Tests written before implementation
- [ ] All tests pass
- [ ] Coverage >=90% on modified files